### PR TITLE
test with `Additional_repositories` instead of `Remotes`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,6 +39,11 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Add internal-cran to repos list
+        run: |
+          cat('\nlocal({\n  r <- getOption("repos")\n  r["Internal CRAN"] <- "https://dragosmg.github.io/internal-cran/"\n  options(repos = r)\n})', file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,11 +38,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
-      - name: Add internal-cran to repos list
-        run: |
-          cat('\nlocal({\n  r <- getOption("repos")\n  r["Internal CRAN"] <- "https://dragosmg.github.io/internal-cran/"\n  options(repos = r)\n})', file = "~/.Rprofile", append = TRUE)
-        shell: Rscript {0}
+          extra-repositories: 'https://dragosmg.github.io/internal-cran/'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: 'https://dragosmg.github.io/internal-cran/'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: 'https://dragosmg.github.io/internal-cran/'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,7 @@ Imports:
     packageB
 Suggests: 
     testthat (>= 3.0.0)
-Remotes: 
-    dragosmg/packageA,
-    dragosmg/packageB
+Additional_repositories: https://dragosmg.github.io/internal-cran
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
     packageB
 Suggests: 
     testthat (>= 3.0.0)
-Additional_repositories: https://dragosmg.github.io/internal-cran
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: packageC
 Title: What the Package Does (One Line, Title Case)
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person("Dragoș", "Moldovan-Grünfeld", , "dragos.mold@gmail.com", role = c("aut", "cre"))
 Description: What the package does (one paragraph).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # packageC 0.1.2
 
+* modifies the GitHub Actions workflow files to allow installation from the `internal-cran` (instead of relying on the DESCRIPTION `Remotes`)
+
 # packageC 0.1.1
 
 * `add_eight()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# packageC 0.1.2
+
 # packageC 0.1.1
 
 * `add_eight()`

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,6 @@
+.onLoad <- function(libname, pkgname) {
+  repos = getOption("repos")
+  repos["Internal CRAN"] = "https://dragosmg.github.io/internal-cran"
+  options(repos = repos)
+  invisible(repos)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,0 @@
-.onLoad <- function(libname, pkgname) {
-  repos = getOption("repos")
-  repos["Internal CRAN"] = "https://dragosmg.github.io/internal-cran"
-  options(repos = repos)
-  invisible(repos)
-}


### PR DESCRIPTION
This PR solves the issue where {renv} installs from GitHub (as it gives precedence to the `Remotes` field in DESCRIPTION)